### PR TITLE
Update build_wheels.sh for Python 3.12 and torch 2.5.1

### DIFF
--- a/tools/build_wheels.sh
+++ b/tools/build_wheels.sh
@@ -16,19 +16,24 @@ export UV_HTTP_TIMEOUT=300
 
 export venvdir=".venv_$(date +%Y.%m.%d_%H.%M.%S)"
 
-uv venv $venvdir --python=3.10
+uv venv $venvdir --python=3.12
 source $venvdir/bin/activate
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # These pip dependencies need to be adjusted to match polez, especially pytorch.
-uv pip install pip setuptools wheel openmim 'numpy<2.0.0'
+# Pin setuptools<70 because mmcv's setup.py imports pkg_resources which was
+# removed in setuptools 70+. We also use --no-build-isolation below so that
+# the build picks up this pinned version.
+uv pip install pip 'setuptools<70' wheel openmim 'numpy<2.0.0'
 
 # Install Pytorch with pip because uv pip install does not work well.
-python -m pip install 'torch==2.4.1' torchaudio torchvision --index-url=https://pypi.org/simple --extra-index-url=https://download.pytorch.org/whl/cu126
+python -m pip install 'torch==2.5.1' torchaudio torchvision --index-url=https://pypi.org/simple --extra-index-url=https://download.pytorch.org/whl/cu124
 
-# Build openmmlab wheels
-python -m pip wheel --no-deps --no-binary=:all: --wheel-dir="$WHEEL_DIR" \
+# Build openmmlab wheels.
+# --no-build-isolation: use the venv's pinned setuptools (with pkg_resources)
+# instead of letting pip install the latest setuptools in an isolated env.
+python -m pip wheel --no-deps --no-binary=:all: --no-build-isolation --wheel-dir="$WHEEL_DIR" \
     'git+https://github.com/open-mmlab/mmcv.git@v2.1.0#egg=mmcv' \
     'git+https://github.com/open-mmlab/mmengine.git@v0.10.7#egg=mmengine' \
     'git+https://github.com/open-mmlab/mmdetection.git@v3.2.0#egg=mmdet' \


### PR DESCRIPTION
## Summary
- Update Python 3.10 -> 3.12 and torch 2.4.1 -> 2.5.1 to match polez requirements
- Pin `setuptools<70` because mmcv's `setup.py` imports `pkg_resources` which was removed in setuptools 70+
- Add `--no-build-isolation` so the build uses the venv's pinned setuptools instead of downloading the latest in an isolated env
- Use `cu124` PyTorch wheel index to match CUDA 12.4 toolkit

## Test plan
- [x] Ran `build_wheels.sh wheelhouse` end-to-end on a machine with RTX 3090 / CUDA 12.4
- [x] All 5 wheels built successfully:
  - `mmcv-2.1.0.20260302-0torch2.5.1numpy1.26.4-cp312-cp312-linux_x86_64.whl` (194M, with CUDA ops)
  - `mmdet-3.2.0.20260302-0torch2.5.1numpy1.26.4-py3-none-any.whl` (6.8M)
  - `mmdet3d-1.4.0.20260302-0torch2.5.1numpy1.26.4-py3-none-any.whl` (3.6M)
  - `mmengine-0.10.7.20260302-0torch2.5.1numpy1.26.4-py3-none-any.whl` (1.7M)
  - `torchsparse-1.4.0.20260302-0torch2.5.1numpy1.26.4-cp312-cp312-linux_x86_64.whl` (32M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)